### PR TITLE
Rules update based on Play Test

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -14,37 +14,39 @@ The game consists of a series of cards and tokens.
 
 - Shuffle the **Role** cards together to create the **Roles Deck**.
 - Each **Player** chooses / is assigned a **Role** card from the **Roles Deck**.
-- Seperate the **Starting Insight** cards from the **Ideas Deck**, and deal one to each player.
-- **Event**, **Insight** and any remaining **Starting Insight** cards are shuffled together to form the **Ideas Deck**. 
-- Deal 1 card to each player from the **Ideas Deck**. Then place the **Ideas Deck** face down on the playing table.
-- Suffle the **Tools Deck**, and deal 1 card to each player. Then place the **Tools Deck** face down on the playing table.
-- Shuffle the **Impacts Deck**, and place the cards face down on the playing table.
-- Seperate the **Green Tokens** and **Red Tokens** into 2 seperate piles, and place them on the playing area.
+- Seperate the **Starting Insight** cards from the other **Idea** Cards, and deal one to each player.
+- Deal 1 additional **Idea** card to each player then shuffle in the **Event** cards to form **Ideas Deck**.  
+- Place the **Ideas Deck** face down on the playing table.
+- Suffle the **Tools Deck**, and place the top 3 cards face up on the playing table for all players to see to form the **Tool Shop**.
+- Place the **Tools Deck** face down on the playing table.
+- Seperate the **Green Open Access Tokens** and **Orange Restricted Access Tokens** into 2 seperate piles, and place them on the playing area.
 - Choose which **Player** will go first. As a suggestion, perhaps who travelled the furthest to join.
 
-Setup is now complete, and each player should have 3 cards in their hand.
+Setup is now complete, and each player should have 2 cards in their hand.
 
 ## Gameplay
 
-A typical game round consists of the current **Player** using actions to gather and progress science. On their turn, a **Player** may take up to 2 **Actions** before handing over clockwise to the next player.
+A typical game round consists of the current **Player** using actions to gather and progress science. On their turn, a **Player** must Draw a Card from the **Ideas Deck** and may take up to 2 **Actions** before handing over clockwise to the next player.
 
-The game is won when 5 **Insights** have been **Disseminated**. If you reach the end of the **Ideas Deck** and no further **Actions** can be taken the game is lost.
+The game is won when 5 **Insights** have been **Disseminated**. If a player cannot draw a card from the **Ideas Deck** at the start of their turn the game is lost.
 
-In addition to the main shared objective, **Players** also have an additional, optionaly, objective to complete that is determined by their **Role** card. These 
+In addition to the main shared objective, **Players** also have an additional, personal objective to complete that is determined by their **Role** card. If the group objective is completed, Players who complete their personal objective Double Win. If the group objective is not completed all Players lose, even if they met their personal objective.
 
 ## Action Types
 
 During the game, a **Player** on their current turn may perform up to 2 **Actions** from the list below.
- **Ponder**: Draw a card from either the **Ideas Deck** or the **Tools Deck** and adds it to their **Hand**.
+
+- **Ponder**: Draw a card from the **Ideas Deck** add it to their **Hand**.
 - **Research**: Turns an **Idea** card in their **Hand** into an **Output** by placing it in front of them on the table.
-- **Disseminate**: **Player** places a **Open Access** or **Restricted Access** token onto one of their Research **Outputs**. Note that if you **Disseminate** an **Insight**, you MUST also draw and resolve a card from the **Impact Deck**.
-- **Teach**: Gift a **Tool** card from their **Hand** to another player.
+- **Disseminate**: **Player** places a **Open Access** or **Restricted Access** token onto one of their Research **Outputs**.
+- **Learn**: Select one of the Tools from your **Hand** or the three visable in the **Tool Shop** and place it under your **Role** Card such that you can see the effect. Each Player may only have 2 Tools active at any one time. If the Player already has two Tools active, on can be returned to their Hand to be **Relearned** at a later date.
 
 ## Card Types
 
 ### **Idea**
 
 **Ideas** can be **Researched** in order to produce **Outputs**. When an **Idea** has been **Researched** place it on the play area in front of you. There are 4 types of idea card listed below.
+
   - **Methods**
   - **Data Sets**
   - **Analysis**
@@ -58,21 +60,17 @@ Each **Idea** card may have a list of requirements that must be met before they 
 
 ### **Event** 
 
-**Events** must be acted upon immediately when drawn and may be permanent or one-off and only affects the current player. Events can either be positive or negative, for example limiting a players ability to perform a specific action.
-
-### **Impact**
-
-When an **Insight** is **Disseminated**, the current player must draw a card from the top of the **Impact** deck, read the text aloud and then act on the text of the card imediately.
+**Events** must be acted upon immediately when drawn and may be permanent or one-off and only affects the current player. Events can either be positive or negative, for example limiting a players ability to perform a specific action. **Global Events** affect all Players.
 
 ### **Roles**
 
-Each **Role** has **Skills** and **Limitations** alongside a **Personal Objective**. Roles are used to vary gameplay by providing players with various different strengths. **Skills** typically allow a player to perform an **action** at a reduced cost.
+Each **Role** has **Skills** and **Limitations** alongside a **Personal Objective**. Roles are used to vary gameplay by providing players with various different strengths. **Skills** typically allow a player to perform an **Action** at a reduced cost.
 
 # Glossary of Terms
 
 ### Restricting **Access**
 
-When a player **Desiminates** a card they MUST choose if that card is **Open Access**, and hence available for all players to use, or if the card is **Restricted Access**, and hence only accessible exclusively to them. Tokens are placed on cards to denote the accessibility of the card, where a **Green Token** indicates a card is **Open Access**, and a **Red Token** indicates that a card is **Restricted Access**
+When a player **Desiminates** a card they MUST choose if that card is **Open Access**, and hence available for all players to use, or if the card is **Restricted Access**, and hence only accessible exclusively to them. Tokens are placed on cards to denote the accessibility of the card, where a **Green Token** indicates a card is **Open Access**, and an **Orange Token** indicates that a card is **Restricted Access**
 
 ### Open Access
 
@@ -80,12 +78,8 @@ An **Output** with **Open Access**, indicated by a **Green Token**, is freely ac
 
 ### Restricted Access
 
-An **Output** with **Restricted Access**, indicated by a **Red Token**, can ONLY be accessed by the player who **Desiminated** the card.
+**Roles** and some permanent **Events** may indicate that a Player cannot access **Restricted Access Outputs**  indicated by a **Orange Token**.
 
-### Invalidating Cards
+### Retractions
 
-At points in the game, normally as a result of resolving an event card, a **Player** may be instructed to remove an **Output** from the game. To remove an **Output**, the **Player** should move the card of their choice to the **Idea Deck** discard pile, along with any other **Outputs** that depended on it.
-
-### Impact Cards
-
-During the game, whenever an **Insight** is **Desiminated** the current **Player** MUST draw and resolve 1 **Impact Card** from the **Impact Deck**. Impace cards can be either positive or negative, but unlike a standard **Event Card** affect the entire group.
+If a Player is instructed to **Retract** a **Research Output** the **Player** should shuffle the card of their choice back into the **Idea Deck**, along with any other **Outputs** that depended on it.


### PR DESCRIPTION
Based on Play Test #3 

## Summary of Major Changes

- Top 3 **Tools** are revealed and **Players** can choose which one to **Learn**.
- When one is taken by a **Player** it is replaced by another one from the **Tool Deck**.
- **Players** can only have 2 **Tools** active at any one time. The rest they keep in their **Hand**.
- **Players** can use an **Action** to **Relearn** a **Tool** from their **Hand**, returning one of their other active **Tools** to their **Hand**

## Motivation

- Introduces more strategy for **Tool** selection. Less based on chance.
- Makes it easier to keep track of the cost of certain **Actions** because each Player only ever has two **Tool** effects (plus **Role** effects and **Event** effects) to apply.
- More realistic narrative. In real life you can choose what tools to learn (from a small pool of those you are 'aware' of. In real life, you can't learn something once and remember it forever. If you don't use a tool for awhile you often have to relearn it.